### PR TITLE
Properly escape values when building PostgreSQL statements

### DIFF
--- a/source/database/driver/connection.d
+++ b/source/database/driver/connection.d
@@ -46,6 +46,9 @@ interface Connection
     }
 
     void begin(); 
-	void rollback();
-	void commit();
+    void rollback();
+    void commit();
+
+    string escapeLiteral(string msg);
+    string escapeIdentifier(string msg);
 }

--- a/source/database/driver/dialect.d
+++ b/source/database/driver/dialect.d
@@ -4,9 +4,7 @@ import database;
 
 interface Dialect
 {
-    string closeQuote(); 
-    string  openQuote();
-	Variant fromSqlValue(DlangDataType fieldType,Variant fieldValue);
+    Variant fromSqlValue(DlangDataType fieldType,Variant fieldValue);
     string toSqlValueImpl(DlangDataType type,Variant value);
     string toSqlValue(T)(T val)
     {
@@ -14,5 +12,4 @@ interface Dialect
         DlangDataType type = getDlangDataType!T(val);
         return toSqlValueImpl(type, value);
     }
-
 }

--- a/source/database/driver/mysql/connection.d
+++ b/source/database/driver/mysql/connection.d
@@ -188,6 +188,18 @@ class MysqlConnection : Connection
     string toSql(long s) {
         return to!string(s);
     }
+
+    string escapeLiteral(string msg)
+    {
+        // FIXME: Escape value properly to prevent accidental SQL injection
+        return `"` ~ msg ~ `"`;
+    }
+
+    string escapeIdentifier(string msg)
+    {
+        // FIXME: Escape db identifier properly to prevent accidental SQL injection
+        return msg;
+    }
 }
 
 cstring toCstring(string c) 

--- a/source/database/driver/mysql/dialect.d
+++ b/source/database/driver/mysql/dialect.d
@@ -4,8 +4,8 @@ import database;
 
 class MysqlDialect : Dialect
 {
-	string closeQuote() { return "\""; }
-	string openQuote()  { return "\""; }
+	string closeQuote() { return `"`; }
+	string openQuote()  { return `"`; }
 	Variant fromSqlValue(DlangDataType type,Variant value)
 	{
 		if(typeid(type) == typeid(dBoolType)){

--- a/source/database/driver/postgresql/binding.d
+++ b/source/database/driver/postgresql/binding.d
@@ -200,6 +200,9 @@ extern(System) {
 
     char *PQresultErrorMessage(const PGresult *res);
 
+    char *PQescapeLiteral(PGconn*,const(char)*,size_t);
+    char *PQescapeIdentifier(PGconn*,const(char)*,size_t);
+
     // date
 
     /* see pgtypes_date.h */

--- a/source/database/driver/postgresql/connection.d
+++ b/source/database/driver/postgresql/connection.d
@@ -13,8 +13,6 @@ module database.driver.postgresql.connection;
 
 import database;
 version(USE_POSTGRESQL):
-pragma(lib, "pq");
-pragma(lib, "pgtypes");
 
 class PostgresqlConnection :  Connection 
 {
@@ -125,22 +123,48 @@ class PostgresqlConnection :  Connection
     
     }
     
-	void begin()
-	{
+    void begin()
+    {
         execute_sql("begin");
-	}
-	void rollback()
-	{
+    }
+
+    void rollback()
+    {
         execute_sql("rollback");
-	}
-	void commit()
-	{
+    }
+
+    void commit()
+    {
         execute_sql("commit");
-	}
+    }
 
     private void execute_sql(string sql)
     {
         reconnect();
         PQexec(con,toStringz(sql));
+    }
+
+    string escapeLiteral(string msg)
+    {
+        auto buf = PQescapeLiteral(con, msg.toStringz, msg.length);
+        if (buf is null)
+            throw new DatabaseException("Unable to escape value: " ~ msg);
+
+        string res = buf.fromStringz.to!string;
+        PQfreemem(buf);
+
+        return res;
+    }
+
+    string escapeIdentifier(string msg)
+    {
+        auto buf = PQescapeIdentifier(con, msg.toStringz, msg.length);
+        if (buf is null)
+            throw new DatabaseException("Unable to escape value: " ~ msg);
+
+        string res = buf.fromStringz.to!string;
+        PQfreemem(buf);
+
+        return res;
     }
 }

--- a/source/database/driver/postgresql/dialect.d
+++ b/source/database/driver/postgresql/dialect.d
@@ -6,6 +6,7 @@ class PostgresqlDialect : Dialect
 {
 	string closeQuote() { return "'"; }
 	string openQuote()  { return "'"; }
+
 	Variant fromSqlValue(DlangDataType type,Variant value)
 	{
 		if(typeid(type) == typeid(dBoolType)){
@@ -37,7 +38,6 @@ class PostgresqlDialect : Dialect
 		else
 			return openQuote ~ value.toString ~ closeQuote;
 	}
-
 }
 
 string[] PGSQL_RESERVED_WORDS = [

--- a/source/database/driver/sqlite/connection.d
+++ b/source/database/driver/sqlite/connection.d
@@ -165,6 +165,18 @@ class SQLiteConnection : Connection
         if (closed)
         throw new DatabaseException("Connection is already closed");
     }
+
+    string escapeLiteral(string msg)
+    {
+        // FIXME: Escape value properly to prevent accidental SQL injection
+        return `"` ~ msg ~ `"`;
+    }
+
+    string escapeIdentifier(string msg)
+    {
+        // FIXME: Escape db identifier properly to prevent accidental SQL injection
+        return msg;
+    }
 }  
 extern(C) int myCallback(void *a_parm, int argc, char **argv,
                          char **column)

--- a/source/database/statement.d
+++ b/source/database/statement.d
@@ -29,11 +29,13 @@ class Statement
     this(Pool pool)
     {
         this._pool = pool;
+        this._conn = pool.getConnection();
     }
 
     this(Pool pool,string sql)
     {
         this._pool = pool;
+        this._conn = pool.getConnection();
         prepare(sql);
     }
 
@@ -68,7 +70,7 @@ class Statement
     void setParameter(T = string)(string key, T value)
     {
         assert(key in param_value);
-        param_value[key] = _pool.dialect.openQuote ~ value.to!string ~ _pool.dialect.closeQuote;
+        param_value[key] = _conn.escapeLiteral(value.to!string);
     }
 
     string sql()


### PR DESCRIPTION
This patch should fully resolve the value-quoting and SQL-injection issues described in https://github.com/huntlabs/database/issues/6 for PostgreSQL (some work specific to MySQL and SQLite is still needed).

PostgreSQL has dedicated support functions to escape values and identifiers, so I used them here. The downside is that they require an active connection, and therefore the escape functions can not live in the `Dialect` classes, but need to be in the classes implementing the `Connection` interface.
This works pretty well though, and allows a similar approach for MySQL and SQLite later.