### PR TITLE
Fix array index var to type of size_t for working on both x86 and x64…

### DIFF
--- a/source/database/url.d
+++ b/source/database/url.d
@@ -1153,7 +1153,7 @@ string punyDecode(string input) {
 	// let i = 0
 	// let bias = initial_bias
 	// let output = an empty string indexed from 0
-	ulong i = 0;
+	size_t i = 0;
 	auto bias = initialBias;
 	dchar[] output;
 	// This reserves a bit more than necessary, but it should be more efficient overall than just
@@ -1173,7 +1173,7 @@ string punyDecode(string input) {
 	}
 
 	// while the input is not exhausted do begin
-	ulong pos = 0;
+	size_t pos = 0;
 	while (pos < input.length) {
 		//   let oldi = i
 		//   let w = 1


### PR DESCRIPTION
Fix for #9 

when accessing an array, index var. must have a type of size_t for building on various platforms.