### PR TITLE
Add support for Meson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,36 @@
 language: d
 sudo: false
+
 os:
  - linux
  - osx
+
 d:
   - dmd
   - ldc
+
+addons:
+  apt:
+    packages:
+    - pkg-config
+    - libpq-dev
+    - libsqlite3-dev
+    - libmysqlclient-dev
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pyenv global system 3.6; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install 'meson>=0.46'; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip .ntmp/ninja-linux.zip -d .ntmp; fi
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -j8 -C build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -j8 -C build test -v; fi
+  - dub --help | tail -n 1
+  - dub build --compiler=$DC
+  - dub test --compiler=$DC

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,159 @@
+project('hunt-database', 'd',
+    meson_version: '>=0.46',
+    license: 'Apache-2.0',
+
+    version: '0.1.8'
+)
+
+project_soversion = '0'
+
+src_dir = include_directories('source/')
+pkgc = import('pkgconfig')
+
+database_src = [
+    'source/database/database.d',
+    'source/database/defined.d',
+    'source/database/driver/builder.d',
+    'source/database/driver/connection.d',
+    'source/database/driver/dialect.d',
+    'source/database/driver/expression.d',
+    'source/database/driver/factory.d',
+    'source/database/driver/mysql/binding.d',
+    'source/database/driver/mysql/builder.d',
+    'source/database/driver/mysql/connection.d',
+    'source/database/driver/mysql/dialect.d',
+    'source/database/driver/mysql/resultset.d',
+    'source/database/driver/mysql/syntax.d',
+    'source/database/driver/postgresql/binding.d',
+    'source/database/driver/postgresql/builder.d',
+    'source/database/driver/postgresql/connection.d',
+    'source/database/driver/postgresql/dialect.d',
+    'source/database/driver/postgresql/resultset.d',
+    'source/database/driver/postgresql/syntax.d',
+    'source/database/driver/resultset.d',
+    'source/database/driver/sqlite/binding.d',
+    'source/database/driver/sqlite/builder.d',
+    'source/database/driver/sqlite/connection.d',
+    'source/database/driver/sqlite/dialect.d',
+    'source/database/driver/sqlite/resultset.d',
+    'source/database/driver/sqlite/syntax.d',
+    'source/database/driver/syntax.d',
+    'source/database/exception.d',
+    'source/database/option.d',
+    'source/database/package.d',
+    'source/database/pool.d',
+    'source/database/row.d',
+    'source/database/statement.d',
+    'source/database/transaction.d',
+    'source/database/url.d',
+    'source/database/utils.d'
+]
+install_subdir('source/database', install_dir: 'include/d/hunt-database/')
+
+# determine the right version flag for the compiler we use
+dc = meson.get_compiler('d')
+dc_version_arg = '-fversion='
+if dc.get_id() == 'llvm'
+    dc_version_arg = '-d-version='
+elif dc.get_id() == 'dmd'
+    dc_version_arg = '-version='
+endif
+
+# construct a bunch of libraries for each selected driver
+foreach driver : get_option('drivers')
+    if driver == 'postgres'
+        pq_dep = dependency('libpq', version: '>= 9.6')
+        lib_deps = [pq_dep]
+
+        lib_name = 'hunt-database-postgres'
+        version_flags = ['USE_POSTGRESQL']
+        lib_description = 'Database abstraction layer for D - Built for PostgreSQL.'
+
+    elif driver == 'mysql'
+        mysql_dep = dependency('mysqlclient')
+        lib_deps = [mysql_dep]
+
+        lib_name = 'hunt-database-mysql'
+        version_flags = ['USE_MYSQL']
+        lib_description = 'Database abstraction layer for D - Built for MySQL.'
+
+    elif driver == 'sqlite'
+        sqlite_dep = dependency('sqlite3')
+        lib_deps = [sqlite_dep]
+
+        lib_name = 'hunt-database-sqlite'
+        version_flags = ['USE_SQLITE']
+        lib_description = 'Database abstraction layer for D - Built for SQLite.'
+
+    elif driver == 'multi'
+        pq_dep = dependency('libpq', version: '>= 9.6')
+        mysql_dep = dependency('mysqlclient')
+        sqlite_dep = dependency('sqlite3')
+        lib_deps = [pq_dep, mysql_dep, sqlite_dep]
+
+        lib_name = 'hunt-database-multi'
+        version_flags = ['USE_POSTGRESQL', 'USE_MYSQL', 'USE_SQLITE']
+        lib_description = 'Database abstraction layer for D - Built for all supported database drivers.'
+
+    else
+        error('Unknown driver selected!')
+    endif
+
+
+    db_lib = library(lib_name,
+        [database_src],
+        include_directories: [src_dir],
+        dependencies: lib_deps,
+        install: true,
+        version: meson.project_version(),
+        soversion: project_soversion,
+        d_module_versions: version_flags
+    )
+
+    pkgc.generate(name: lib_name,
+        libraries: db_lib,
+        subdirs: 'd/hunt-database/',
+        version: meson.project_version(),
+        d_module_versions: version_flags,
+        description: lib_description
+    )
+
+    ver_dc_args = []
+    foreach v : version_flags
+        ver_dc_args += [dc_version_arg + v]
+    endforeach
+
+
+    # this dumb code repetition exists to allow other Meson projects to embed this as subproject easily,
+    # and to achieve that we need to declare dependencies with different variable names.
+    if driver == 'postgres'
+        hdb_postgres_dep = declare_dependency(
+            link_with: [db_lib],
+            include_directories: [src_dir],
+            compile_args: ver_dc_args
+        )
+
+    elif driver == 'mysql'
+        hdb_mysql_dep = declare_dependency(
+            link_with: [db_lib],
+            include_directories: [src_dir],
+            compile_args: ver_dc_args
+        )
+
+    elif driver == 'sqlite'
+        hdb_sqlite_dep = declare_dependency(
+            link_with: [db_lib],
+            include_directories: [src_dir],
+            compile_args: ver_dc_args
+        )
+
+    elif driver == 'multi'
+        hdb_multi_dep = declare_dependency(
+            link_with: [db_lib],
+            include_directories: [src_dir],
+            compile_args: ver_dc_args
+        )
+
+    endif
+
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -70,7 +70,11 @@ foreach driver : get_option('drivers')
         lib_description = 'Database abstraction layer for D - Built for PostgreSQL.'
 
     elif driver == 'mysql'
-        mysql_dep = dependency('mysqlclient')
+        mysql_dep = dependency('mysqlclient', required: false)
+        if not mysql_dep.found()
+            warning('Unable to find libmysqlclient, continuing anyway, assuming it exists.')
+            mysql_dep = declare_dependency(link_args: '-lmysqlclient')
+        endif
         lib_deps = [mysql_dep]
 
         lib_name = 'hunt-database-mysql'
@@ -87,8 +91,12 @@ foreach driver : get_option('drivers')
 
     elif driver == 'multi'
         pq_dep = dependency('libpq', version: '>= 9.6')
-        mysql_dep = dependency('mysqlclient')
         sqlite_dep = dependency('sqlite3')
+
+        if not mysql_dep.found()
+            warning('Unable to find libmysqlclient, continuing anyway, assuming it exists.')
+            mysql_dep = declare_dependency(link_args: '-lmysqlclient')
+        endif
         lib_deps = [pq_dep, mysql_dep, sqlite_dep]
 
         lib_name = 'hunt-database-multi'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,7 @@
+# Build options for Hunt-Database
+
+option('drivers',
+    type: 'array',
+    choices : ['postgres', 'mysql', 'sqlite', 'multi'],
+    description: 'Enabled database drivers to build libraries for.'
+)


### PR DESCRIPTION
Hi!
I am making an attempt to port the Laniakea Debian archive management suite (see [1]) to hunt-database and hunt-entity.
There is a whole bunch of issues ahead, unfortunately, so you can expect a bunch of bug reports and pull requests soon, when I get the time to do the actual port and can test the result on our live instance.

In order to use hunt-database at all though, I need to be able to integrate it with the Meson build system[2], which is a bit more versatile than dub for bigger projects, and used by large projects in the Linux world, such as X, GNOME, systemd, etc.

This patch adds Meson build support to hunt-database. I will maintain this build system for you for as long as I'll use hunt-database/entity (which hopefully will be for a really long time, especially since there is no good alternative to it in the D world that is also actively maintained).

Meson builds all flavors of hunt-database by default (postgres, sqlite, mysql, multi), so Linux distribution package managers have an easy time and projects using the library via Meson can easily pick the flavor they want.

How to test:
```sh
sudo apt install meson
mkdir build && cd build
meson ..
ninja
DESTDIR=/tmp/install-test ninja install
```

In accordance with https://github.com/huntlabs/entity/issues/11, Meson calls this library "hunt-database", or "hdb" (in case short names are needed). This will make it easier to add the software to distributions later, where the generic library name would be a problem.

Thanks for considering!


[1]: https://github.com/lkorigin/laniakea
[2]: https://mesonbuild.com/