### PR TITLE
mysql dialect: quote string.

### DIFF
--- a/source/hunt/database/driver/mysql/Dialect.d
+++ b/source/hunt/database/driver/mysql/Dialect.d
@@ -29,6 +29,7 @@ class MysqlDialect : Dialect
 		else
 			return value;
 	}
+	
 	string toSqlValueImpl(DlangDataType type,Variant value)
 	{
 		if(typeid(type) == typeid(dBoolType))
@@ -42,9 +43,18 @@ class MysqlDialect : Dialect
 		}
 		else if(typeid(type) == typeid(dIntType))
 			return value.toString;
+		else if(typeid(type) == typeid(dStringType))
+			return _db.escapeIdentifier(quoteString(value.toString));
 		else
-			return _db.escapeIdentifier( value.toString);
+			return _db.escapeIdentifier(value.toString);
 	}
+
+	string quoteString(in string str) {
+		import std.array : replace;
+
+		return "'" ~ str.replace("'", "''") ~ "'";
+	}
+
 	string getColumnDefinition(ColumnDefinitionInfo info) {
 		if (!(info.dType in DTypeToPropertyType))
 			throw new Exception("unsupport type %d of %s".format(info.dType,info.name));
@@ -147,7 +157,7 @@ class MysqlDialect : Dialect
 
 
 
-string[] MYSQL_RESERVED_WORDS = 
+string[] MYSQL_RESERVED_WORDS =
 [
 "ACCESSIBLE", "ADD", "ALL",
 	"ALTER", "ANALYZE", "AND",


### PR DESCRIPTION
Hi,

It fix working with criteria builder and string id.

Indeed with an entity with a string id, entityManager.save() fail to check id existence.

Example of failing code without the patch:

```
@Table("t_version")
class Version
{
    mixin MakeEntity;

    @Id
    @PrimaryKey
    string id;

    string value;
}

auto repo = new VersionRepository();
auto version = new Version();
version.id = "foo";
version.value = "bar";

repo.save(version); // ok do an INSERT
repo.save(version); // fail, must do an UPDATE but try to do an INSERT
```


And it allow to remove all unnecessary manual quote in code like in this statement:

`auto p1 = objects.builder.equal(objects.root.User.email, '"' ~ email ~ '"');`